### PR TITLE
Improve sodiumBool and anniversaryBool description

### DIFF
--- a/calculators/salt.html
+++ b/calculators/salt.html
@@ -37,7 +37,7 @@
             </tr>
             <tr>
                 <td>
-                    (LE) Sodium Base?
+                    (LE) Setup uses Sodium Base
                 </td>
                 <td>
                     <input type="checkbox" name="sodiumBool" id="sodiumBool">
@@ -45,7 +45,7 @@
             </tr>
             <tr>
                 <td>
-                    (LE) Anniversary Trap?
+                    (LE) Setup uses Anniversary Trap
                 </td>
                 <td>
                     <input type="checkbox" name="anniversaryBool" id="anniversaryBool">


### PR DESCRIPTION
When accessing this tool, I was confused about whether to check the LE checkboxes given my situation - I had them but did not arm the setups when I input the values for Power Luck. From what I understood in the code, both checkboxes were referring to the setup described by the Power and Luck fields.

As this tool is now linked on the Discord server with `... salt`, I thought this could be made a little clearer without losing its brevity. 